### PR TITLE
Removing node modules after build for less used memory

### DIFF
--- a/einkaufsliste_frontend/dockerfile
+++ b/einkaufsliste_frontend/dockerfile
@@ -50,10 +50,13 @@ FROM nginx:1.13.9-alpine
 COPY nginx.conf /etc/nginx/nginx.conf
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /usr/src/app/dist/einkaufsliste_frontend /usr/share/nginx/html
+RUN rm -rf /usr/src/app/node_modules
 
 RUN echo "mainFileName=\"\$(ls /usr/share/nginx/html/main*.js)\" && \
     envsubst '\$BACKEND_URL \$FRONTEND_URL \$DJANGO_APP_CLIENT_ID \$DJANGO_APP_CLIENT_SECRET \
-     \$GOOGLE_API_KEY_CLIENT_ID ' < \${mainFileName} > main.tmp && \
+    \$GOOGLE_API_KEY_CLIENT_ID ' < \${mainFileName} > main.tmp && \
     mv main.tmp  \${mainFileName} && nginx -g 'daemon off;'" > run.sh
+
+
 
 ENTRYPOINT ["sh", "run.sh"]


### PR DESCRIPTION
Not a fix for the issue but at least using less memory for frontend dontainer.